### PR TITLE
Add portfolio, insights, and observability enhancements

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,37 @@
+# Core application settings
+APP_NAME=Market Matrix
+API_V1_STR=/api/v1
+VERSION=0.2.0
+
+# Database & cache (defaults to local development values)
+DATABASE_URL=sqlite:///./crypto.db
+REDIS_URL=redis://localhost:6379/0
+
+# Feature flags (1 = enabled, 0 = disabled)
+FEATURE_PREDICTIONS=1
+FEATURE_DASHBOARD=1
+FEATURE_ADVANCED_TOOLS=1
+FEATURE_WEB3_HEALTH=1
+FEATURE_PORTFOLIO=0
+FEATURE_INSIGHTS=0
+FEATURE_WALLET=0
+
+# Data + integrations
+DATA_LIVE=0
+COINGECKO_API_KEY=
+BINANCE_API_KEY=
+COINGECKO_BASE_URL=https://api.coingecko.com/api/v3
+BINANCE_BASE_URL=https://api.binance.com/api/v3
+DEXSCREENER_BASE_URL=https://api.dexscreener.com/latest/dex
+
+# Optional community integrations
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+REDDIT_USER_AGENT=market-matrix/0.1
+TRANSFORMERS_LOCAL=0
+OPENAI_API_KEY=
+
+# Queue & scheduling
+PORTFOLIO_SNAPSHOT_SCHEDULE_CRON=0 2 * * *
+REQUEST_RATE_LIMITS=/predictions:60/60,/portfolio/upload:5/60
+CACHE_TTL_SECONDS=60

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.log
 .env
 .env.*
+!.env.sample
 .mypy_cache/
 .pytest_cache/
 dist/

--- a/README_FREE_MVP.md
+++ b/README_FREE_MVP.md
@@ -1,0 +1,122 @@
+# Market Matrix – Free Tier Backend
+
+Market Matrix is a FastAPI backend focused on free-only market intelligence. This build delivers:
+
+- Hardened predictions and market data APIs backed by Prophet and public market feeds.
+- Portfolio CSV ingestion with valuation, allocation and performance snapshots (flag-gated).
+- Community insights powered by on-chain sentiment proxies and optional Reddit/VADER analysis (flag-gated).
+- DexScreener-based Web3 health metrics with caching and graceful degradation.
+- Observability endpoints (`/health`, `/metrics`) with dependency checks and Prometheus output.
+- Redis-backed burst rate-limiting and WebSocket feeds supporting multi-symbol subscriptions.
+
+All functionality works with free APIs (CoinGecko, Binance public, DexScreener) and open-source libraries only.
+
+## Getting Started
+
+1. **Install dependencies**
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. **Copy the sample environment**
+
+```bash
+cp .env.sample .env
+```
+
+Populate optional keys as needed:
+
+- `COINGECKO_API_KEY` (optional, improves rate limits)
+- `REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET` (optional community ingestion)
+- `OPENAI_API_KEY` (optional summarisation – default off)
+
+Feature flags toggle modules (`FEATURE_*`). Defaults keep paid integrations disabled. Enable portfolio/insights by flipping to `1`.
+
+3. **Start local services**
+
+Ensure Redis is running (for rate limiting and task queues). For development you can run:
+
+```bash
+redis-server --save "" --appendonly no
+```
+
+Launch the API:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+4. **Run migrations / bootstrap (SQLite dev example)**
+
+```bash
+python scripts/migrate.py
+python scripts/bootstrap_simple.py  # optional sample data
+```
+
+### Background workers
+
+RQ tasks (predictions refresh, nightly portfolio snapshots, optional Reddit ingestion) can be launched with:
+
+```bash
+rq worker -u $REDIS_URL market_matrix
+```
+
+Schedule recurring jobs (cron-style) via `rq-scheduler` or your preferred scheduler referencing `PORTFOLIO_SNAPSHOT_SCHEDULE_CRON`.
+
+## Feature Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `FEATURE_PREDICTIONS` | 1 | Enable forecasting endpoints & websockets |
+| `FEATURE_DASHBOARD` | 1 | Dashboard metadata & market websockets |
+| `FEATURE_ADVANCED_TOOLS` | 1 | Technical indicators, depth, trades |
+| `FEATURE_WEB3_HEALTH` | 1 | DexScreener health endpoint |
+| `FEATURE_PORTFOLIO` | 0 | CSV portfolio upload, holdings, allocation |
+| `FEATURE_INSIGHTS` | 0 | Community insights API |
+| `FEATURE_WALLET` | 0 | Reserved (kept disabled) |
+
+## Smoke Test Commands
+
+```bash
+# Health
+curl -s http://localhost:8000/api/v1/health | jq
+
+# Predictions
+curl -s "http://localhost:8000/api/v1/predictions?symbol=BTC&horizon=4h" | jq
+websocat ws://localhost:8000/api/v1/ws/predictions
+
+# Market tools
+curl -s "http://localhost:8000/api/v1/market/BTC/indicators?set=RSI,MACD,SMA" | jq
+curl -s "http://localhost:8000/api/v1/market/BTC/depth" | jq
+curl -s "http://localhost:8000/api/v1/market/BTC/trades?limit=50" | jq
+
+# Web3 health
+curl -s "http://localhost:8000/api/v1/web3/health?symbol=BTC" | jq
+
+# Portfolio (enable FEATURE_PORTFOLIO=1)
+curl -F "file=@samples/holdings_example.csv" http://localhost:8000/api/v1/portfolio/upload
+curl -s http://localhost:8000/api/v1/portfolio/holdings | jq
+curl -s "http://localhost:8000/api/v1/portfolio/performance?window=30d" | jq
+curl -s http://localhost:8000/api/v1/portfolio/allocation | jq
+
+# Insights (enable FEATURE_INSIGHTS=1)
+curl -s "http://localhost:8000/api/v1/insights/summary?symbol=BTC&window=24h" | jq
+curl -s "http://localhost:8000/api/v1/insights/events?symbol=BTC&limit=10" | jq
+```
+
+## Testing
+
+```bash
+pytest
+```
+
+This suite covers authentication, health checks, predictions, portfolio ingestion, insights and web3 health endpoints.
+
+## Notes
+
+- All external network calls gracefully degrade; cached results are served when vendors fail.
+- WebSockets accept subscription messages: `{ "action": "subscribe", "symbols": ["BTC", "ETH"] }` and stream updates per topic.
+- Rate limiting is configured via `REQUEST_RATE_LIMITS` (path:requests/window). Defaults throttle predictions (60/min) and portfolio uploads (5/min).
+- Optional Reddit ingestion requires PRAW credentials; summarisation stays disabled unless `TRANSFORMERS_LOCAL=1` and models are available locally.

--- a/app/api/middleware/rate_limit.py
+++ b/app/api/middleware/rate_limit.py
@@ -2,44 +2,100 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 from fastapi import Request, Response
+from redis import Redis
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from app.core.config import settings
+from app.core.redis import get_redis_client
 from app.core.responses import error_response
 
 
+RateRule = Tuple[str, int, int]
+
+
+def _parse_rules() -> List[RateRule]:
+    rules: List[RateRule] = []
+    for entry in settings.REQUEST_RATE_LIMITS:
+        try:
+            path, config = entry.split(":", 1)
+            limit_str, window_str = config.split("/")
+            rules.append((path.strip(), int(limit_str), int(window_str)))
+        except ValueError:
+            continue
+    return rules
+
+
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, limit: int = 120, window: int = 60) -> None:
+    def __init__(self, app) -> None:
         super().__init__(app)
-        self.limit = limit
-        self.window = window
+        self.rules = _parse_rules()
+        self.redis: Redis | None = None
+        try:
+            client = get_redis_client()
+            client.ping()
+            self.redis = client
+        except Exception:  # pragma: no cover - fallback for tests
+            self.redis = None
         self.counters: Dict[str, Tuple[int, float]] = {}
 
-    async def dispatch(self, request: Request, call_next) -> Response:
-        identifier = f"{request.client.host}:{request.url.path}"
+    def _match_rule(self, path: str) -> RateRule | None:
+        for rule_path, limit, window in self.rules:
+            if path.startswith(rule_path) or path.startswith(f"{settings.API_V1_STR}{rule_path}"):
+                return rule_path, limit, window
+        return None
+
+    def _consume_redis(self, rule: RateRule, identifier: str) -> Tuple[bool, int, int]:
+        assert self.redis is not None
+        key = f"ratelimit:{rule[0]}:{identifier}"
+        limit, window = rule[1], rule[2]
+        count = self.redis.incr(key)
+        if count == 1:
+            self.redis.expire(key, window)
+        remaining = max(limit - count, 0)
+        ttl = self.redis.ttl(key)
+        if ttl <= 0:
+            ttl = window
+        reset = int(time.time()) + ttl
+        return count <= limit, remaining, reset
+
+    def _consume_memory(self, rule: RateRule, identifier: str) -> Tuple[bool, int, int]:
+        limit, window = rule[1], rule[2]
         now = time.time()
         count, start = self.counters.get(identifier, (0, now))
-
-        if now - start > self.window:
+        if now - start > window:
             count = 0
             start = now
-
         count += 1
         self.counters[identifier] = (count, start)
+        remaining = max(limit - count, 0)
+        reset = int(start + window)
+        return count <= limit, remaining, reset
 
-        if count > self.limit:
+    async def dispatch(self, request: Request, call_next) -> Response:
+        match = self._match_rule(request.url.path)
+        if not match:
+            return await call_next(request)
+
+        identifier = request.client.host or "anonymous"
+        if self.redis:
+            allowed, remaining, reset = self._consume_redis(match, identifier)
+        else:
+            allowed, remaining, reset = self._consume_memory(match, f"{identifier}:{match[0]}")
+
+        if not allowed:
             payload = error_response(
                 code="RATE_LIMIT_EXCEEDED",
                 message="Rate limit exceeded. Try again later.",
                 status_code=429,
-                details={"limit": self.limit, "window": self.window},
+                details={"limit": match[1], "window": match[2]},
             )
             return Response(content=json.dumps(payload), status_code=429, media_type="application/json")
 
         response = await call_next(request)
-        response.headers["X-RateLimit-Limit"] = str(self.limit)
-        response.headers["X-RateLimit-Remaining"] = str(max(self.limit - count, 0))
-        response.headers["X-RateLimit-Reset"] = str(int(start + self.window))
+        response.headers["X-RateLimit-Limit"] = str(match[1])
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
+        response.headers["X-RateLimit-Reset"] = str(reset)
         return response

--- a/app/api/v1/endpoints/dashboard.py
+++ b/app/api/v1/endpoints/dashboard.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.core.features import require_feature
+from app.core.responses import success_response
+
+
+router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
+
+WIDGETS = [
+    {
+        "name": "priceTicker",
+        "description": "Latest price, change and volume",
+        "endpoint": "/market/{symbol}/price",
+        "schema": {
+            "symbol": "string",
+            "price": "float",
+            "change_24h": "float",
+            "volume_24h": "float",
+            "timestamp": "datetime",
+        },
+    },
+    {
+        "name": "ohlcv",
+        "description": "OHLCV candles",
+        "endpoint": "/market/{symbol}/ohlcv",
+        "schema": {
+            "candles": ["timestamp", "open", "high", "low", "close", "volume"],
+        },
+    },
+    {
+        "name": "indicators",
+        "description": "Technical indicators (RSI, MACD, SMA, EMA, BOLL)",
+        "endpoint": "/market/{symbol}/indicators",
+        "schema": {
+            "indicators": ["name", "value", "metadata"],
+        },
+    },
+    {
+        "name": "orderBook",
+        "description": "Aggregated market depth",
+        "endpoint": "/market/{symbol}/depth",
+        "schema": {
+            "bids": ["price", "quantity"],
+            "asks": ["price", "quantity"],
+            "timestamp": "datetime",
+        },
+    },
+    {
+        "name": "recentTrades",
+        "description": "Recent executed trades",
+        "endpoint": "/market/{symbol}/trades",
+        "schema": {
+            "trades": ["trade_id", "price", "quantity", "side", "timestamp"],
+        },
+    },
+    {
+        "name": "predictions",
+        "description": "Model predictions per horizon",
+        "endpoint": "/predictions?symbol={symbol}",
+        "schema": {
+            "predictions": ["horizon", "predicted_price", "confidence_interval", "probability"],
+        },
+    },
+]
+
+
+@router.get("/metadata")
+def dashboard_metadata():
+    require_feature("dashboard")
+    return success_response({"widgets": WIDGETS, "websockets": ["/ws/market", "/ws/predictions"]})

--- a/app/api/v1/endpoints/health.py
+++ b/app/api/v1/endpoints/health.py
@@ -2,44 +2,68 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
-from prometheus_client import CollectorRegistry, generate_latest
+from fastapi import APIRouter, Depends, Response
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Gauge, generate_latest
 
-from app.core.responses import success_response
 from app.api.v1.dependencies import get_db
+from app.core.config import settings
+from app.core.responses import success_response
+from app.services.health import run_health_checks
 
 router = APIRouter(prefix="/health", tags=["Health"])
 
+REGISTRY = CollectorRegistry()
+REQUEST_COUNTER = Counter("market_matrix_requests_total", "Total API requests", registry=REGISTRY)
+FEATURE_GAUGE = Gauge("market_matrix_features_enabled", "Feature flag status", ["feature"], registry=REGISTRY)
 
-@router.get("", summary="Basic health check")
-def health_basic():
-    return success_response({"status": "healthy"})
+
+@router.get("", summary="Service health overview")
+def health_basic(db=Depends(get_db)):
+    checks = run_health_checks(db)
+    all_healthy = all(status.status == "healthy" for status in checks.values())
+    data = {
+        "status": "healthy" if all_healthy else "degraded",
+        "services": {name: status.status for name, status in checks.items()},
+    }
+    return success_response(data)
 
 
-@router.get("/detailed", summary="Detailed service status")
+@router.get("/detailed", summary="Detailed dependency check")
 def health_detailed(db=Depends(get_db)):
-    # Placeholder statuses - in a real system check dependencies
+    checks = run_health_checks(db)
     services = {
-        "database": "healthy",
-        "redis": "healthy",
-        "ml_service": "healthy",
-        "data_ingestion": "healthy",
+        name: {"status": status.status, "details": status.details}
+        for name, status in checks.items()
     }
     metrics = {
-        "uptime_seconds": 0,
-        "total_requests": 0,
-        "active_users": 0,
+        "features": list(settings.enabled_features),
+        "timestamp": datetime.utcnow().isoformat(),
     }
     return success_response({"status": "healthy", "services": services, "metrics": metrics})
 
 
-@router.get("/status", summary="Service dependency status")
-def status():
-    return success_response({"status": "healthy", "timestamp": datetime.utcnow().isoformat()})
+@router.get("/status", summary="Timestamped status")
+def status(db=Depends(get_db)):
+    checks = run_health_checks(db)
+    return success_response(
+        {
+            "status": "healthy" if all(s.status == "healthy" for s in checks.values()) else "degraded",
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+    )
 
 
-@router.get("/metrics", summary="Prometheus metrics", response_model=None)
+@router.get("/metrics", summary="Prometheus metrics", response_class=Response)
 def metrics():
-    registry = CollectorRegistry()
+    registry = REGISTRY
+    for feature in [
+        "predictions",
+        "dashboard",
+        "advanced_tools",
+        "web3_health",
+        "portfolio",
+        "insights",
+    ]:
+        FEATURE_GAUGE.labels(feature=feature).set(1 if getattr(settings, f"FEATURE_{feature.upper()}") else 0)
     data = generate_latest(registry)
-    return success_response({"metrics": data.decode("utf-8")})
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/app/api/v1/endpoints/insights.py
+++ b/app/api/v1/endpoints/insights.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.api.v1.dependencies import get_db
+from app.core.features import require_feature
+from app.core.responses import success_response
+from app.services.insights import list_events, summarise_insights
+
+
+router = APIRouter(prefix="/insights", tags=["Insights"])
+
+
+@router.get("/summary")
+def get_insight_summary(
+    symbol: str = Query(..., min_length=1),
+    window: str = Query("24h"),
+    db: Session = Depends(get_db),
+):
+    require_feature("insights")
+    try:
+        summary = summarise_insights(db, symbol, window)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+    return success_response(summary.model_dump())
+
+
+@router.get("/events")
+def get_insight_events(
+    symbol: str = Query(..., min_length=1),
+    limit: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+):
+    require_feature("insights")
+    events = list_events(db, symbol, limit)
+    return success_response(events.model_dump())

--- a/app/api/v1/endpoints/portfolio.py
+++ b/app/api/v1/endpoints/portfolio.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from sqlalchemy.orm import Session
+
+from app.api.v1.dependencies import get_current_active_user, get_db
+from app.core.features import require_feature
+from app.core.responses import success_response
+from app.models.database.user import User
+from app.services.portfolio import (
+    compute_allocation,
+    fetch_holdings,
+    get_performance,
+    upsert_holdings_from_csv,
+)
+
+
+router = APIRouter(prefix="/portfolio", tags=["Portfolio"])
+
+
+@router.post("/upload")
+async def upload_portfolio(
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    require_feature("portfolio")
+    content = await file.read()
+    try:
+        result = upsert_holdings_from_csv(db, current_user.id, content)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return success_response(result.model_dump())
+
+
+@router.get("/holdings")
+def get_holdings(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    require_feature("portfolio")
+    holdings = fetch_holdings(db, current_user.id)
+    return success_response(holdings.model_dump())
+
+
+@router.get("/allocation")
+def get_allocation(
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    require_feature("portfolio")
+    allocation = compute_allocation(db, current_user.id)
+    return success_response(allocation.model_dump())
+
+
+@router.get("/performance")
+def get_performance_view(
+    window: str = Query("30d", pattern="^(7d|30d|90d)$"),
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    require_feature("portfolio")
+    try:
+        performance = get_performance(db, current_user.id, window)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return success_response(performance.model_dump())

--- a/app/api/v1/endpoints/web3.py
+++ b/app/api/v1/endpoints/web3.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.core.features import require_feature
+from app.core.responses import success_response
+from app.services.web3 import get_web3_health
+
+
+router = APIRouter(prefix="/web3", tags=["Web3"])
+
+
+@router.get("/health")
+def web3_health(symbol: str = Query(..., min_length=1)):
+    require_feature("web3_health")
+    try:
+        health = get_web3_health(symbol)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+    return success_response(
+        {
+            "symbol": health.symbol,
+            "liquidity": health.liquidity,
+            "vol24h": health.vol24h,
+            "txPerHour": health.tx_per_hour,
+            "pools": [
+                {
+                    "address": pool.address,
+                    "chain": pool.chain,
+                    "liquidity": pool.liquidity_usd,
+                    "price": pool.price_usd,
+                }
+                for pool in health.pools
+            ],
+            "lastUpdated": health.last_updated.isoformat(),
+        }
+    )

--- a/app/api/v1/endpoints/websocket.py
+++ b/app/api/v1/endpoints/websocket.py
@@ -1,52 +1,101 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
+from typing import Callable, Dict, Set
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from app.core.config import settings
+from app.core.database import SessionLocal
+from app.services.market_data import get_latest_price
+from app.services.prediction import get_predictions
+
 
 router = APIRouter(prefix="/ws", tags=["WebSocket"])
 
 
+class SubscriptionServer:
+    def __init__(self, max_topics: int, fetcher: Callable[[str], Dict]):
+        self.max_topics = max_topics
+        self.fetcher = fetcher
+        self.subscriptions: Dict[WebSocket, Set[str]] = {}
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.subscriptions[websocket] = set()
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        self.subscriptions.pop(websocket, None)
+
+    async def handle(self, websocket: WebSocket) -> None:
+        await self.connect(websocket)
+        try:
+            while True:
+                try:
+                    message = await asyncio.wait_for(websocket.receive_json(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    await self._push_updates(websocket)
+                    continue
+
+                action = message.get("action")
+                symbols = message.get("symbols") or []
+                if action == "subscribe":
+                    if len(symbols) > self.max_topics:
+                        symbols = symbols[: self.max_topics]
+                    self.subscriptions[websocket] = {symbol.upper() for symbol in symbols}
+                    await websocket.send_json({"type": "subscribed", "symbols": list(self.subscriptions[websocket])})
+                elif action == "unsubscribe":
+                    for symbol in symbols:
+                        self.subscriptions[websocket].discard(symbol.upper())
+                    await websocket.send_json({"type": "unsubscribed", "symbols": list(symbols)})
+        except WebSocketDisconnect:
+            await self.disconnect(websocket)
+
+    async def _push_updates(self, websocket: WebSocket) -> None:
+        symbols = self.subscriptions.get(websocket, set())
+        if not symbols:
+            return
+        for symbol in list(symbols)[: self.max_topics]:
+            payload = await asyncio.get_event_loop().run_in_executor(None, self.fetcher, symbol)
+            if payload:
+                await websocket.send_json(payload)
+
+
+def _fetch_market_payload(symbol: str) -> Dict:
+    with SessionLocal() as session:
+        price = get_latest_price(session, symbol)
+    return {
+        "type": "price_update",
+        "symbol": symbol.upper(),
+        "data": price.model_dump(),
+    }
+
+
+def _fetch_prediction_payload(symbol: str) -> Dict:
+    with SessionLocal() as session:
+        response = get_predictions(session, symbol=symbol, horizons=["1h", "4h", "24h"])
+    return {
+        "type": "prediction_update",
+        "symbol": symbol.upper(),
+        "data": [item.model_dump() for item in response.predictions],
+    }
+
+
+market_server = SubscriptionServer(max_topics=5, fetcher=_fetch_market_payload)
+prediction_server = SubscriptionServer(max_topics=3, fetcher=_fetch_prediction_payload)
+
+
 @router.websocket("/market")
 async def market_feed(websocket: WebSocket):
-    await websocket.accept()
-    try:
-        while True:
-            await websocket.send_json(
-                {
-                    "type": "price_update",
-                    "symbol": "BTC",
-                    "data": {
-                        "price": 20000.0,
-                        "change_24h": 2.5,
-                        "volume_24h": 1_000_000,
-                        "timestamp": datetime.utcnow().isoformat(),
-                    },
-                }
-            )
-            await asyncio.sleep(1)
-    except WebSocketDisconnect:
+    if not settings.FEATURE_DASHBOARD:
+        await websocket.close()
         return
+    await market_server.handle(websocket)
 
 
 @router.websocket("/predictions")
 async def predictions_feed(websocket: WebSocket):
-    await websocket.accept()
-    try:
-        while True:
-            await websocket.send_json(
-                {
-                    "type": "prediction_update",
-                    "symbol": "BTC",
-                    "data": {
-                        "horizon": "24h",
-                        "predicted_price": 21000.0,
-                        "confidence": 0.65,
-                        "timestamp": datetime.utcnow().isoformat(),
-                    },
-                }
-            )
-            await asyncio.sleep(5)
-    except WebSocketDisconnect:
+    if not settings.FEATURE_PREDICTIONS:
+        await websocket.close()
         return
+    await prediction_server.handle(websocket)

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -2,7 +2,19 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import alerts, auth, health, indices, market, predictions, websocket
+from app.api.v1.endpoints import (
+    alerts,
+    auth,
+    dashboard,
+    health,
+    indices,
+    insights,
+    market,
+    portfolio,
+    predictions,
+    web3,
+    websocket,
+)
 
 api_router = APIRouter()
 
@@ -10,7 +22,11 @@ api_router.include_router(auth.router)
 api_router.include_router(market.router)
 api_router.include_router(predictions.router)
 api_router.include_router(predictions.models_router)
+api_router.include_router(dashboard.router)
 api_router.include_router(indices.router)
 api_router.include_router(alerts.router)
 api_router.include_router(health.router)
+api_router.include_router(portfolio.router)
+api_router.include_router(insights.router)
+api_router.include_router(web3.router)
 api_router.include_router(websocket.router)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
-from typing import List
+from typing import List, Sequence
 
+from pydantic import computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -11,7 +12,7 @@ class Settings(BaseSettings):
 
     APP_NAME: str = "CryptoPrediction API"
     API_V1_STR: str = "/api/v1"
-    VERSION: str = "0.1.0"
+    VERSION: str = "0.2.0"
 
     DATABASE_URL: str = "sqlite:///./crypto.db"
     REDIS_URL: str = "redis://localhost:6379/0"
@@ -25,6 +26,11 @@ class Settings(BaseSettings):
     COINGECKO_API_KEY: str | None = None
     BINANCE_API_KEY: str | None = None
     ALPHA_VANTAGE_KEY: str | None = None
+    REDDIT_CLIENT_ID: str | None = None
+    REDDIT_CLIENT_SECRET: str | None = None
+    REDDIT_USER_AGENT: str = "market-matrix/0.1"
+    TRANSFORMERS_LOCAL: bool = False
+    OPENAI_API_KEY: str | None = None
     SENTRY_DSN: str | None = None
     STRIPE_SECRET_KEY: str | None = None
     WEBHOOK_SECRET: str | None = None
@@ -41,13 +47,51 @@ class Settings(BaseSettings):
     SUPPORTED_SYMBOLS: List[str] = ["BTC", "ETH", "SOL", "ADA", "XRP"]
     DEFAULT_TIMEZONE: str = "UTC"
 
+    # Feature flags (defaults mirror free-tier scope)
+    FEATURE_PREDICTIONS: bool = True
+    FEATURE_DASHBOARD: bool = True
+    FEATURE_ADVANCED_TOOLS: bool = True
+    FEATURE_WEB3_HEALTH: bool = True
+    FEATURE_PORTFOLIO: bool = False
+    FEATURE_INSIGHTS: bool = False
+    FEATURE_WALLET: bool = False
+
+    DATA_LIVE: bool = False
+
     ENABLE_EXTERNAL_MARKET_DATA: bool = False
     MARKET_DATA_LOOKBACK_DAYS: int = 30
     MARKET_DATA_PROVIDER: str = "coingecko"
     DEXSCREENER_ENABLED: bool = True
     COINGECKO_BASE_URL: str = "https://api.coingecko.com/api/v3"
     DEXSCREENER_BASE_URL: str = "https://api.dexscreener.com/latest/dex"
+    BINANCE_BASE_URL: str = "https://api.binance.com/api/v3"
     SIMPLE_BOOTSTRAP: bool = False
+
+    REQUEST_RATE_LIMITS: List[str] = ["/predictions:60/60", "/portfolio/upload:5/60"]
+    CACHE_TTL_SECONDS: int = 60
+
+    INSIGHTS_DEFAULT_WINDOW: str = "24h"
+    INSIGHTS_DEX_TREND_WINDOW_MINUTES: int = 120
+
+    PORTFOLIO_SNAPSHOT_SCHEDULE_CRON: str = "0 2 * * *"
+
+    COMMUNITY_SUBREDDITS: List[str] = ["CryptoCurrency", "Bitcoin", "CryptoMarkets"]
+
+    PROMETHEUS_METRIC_NAMESPACE: str = "market_matrix"
+
+    @computed_field
+    @property
+    def enabled_features(self) -> Sequence[str]:  # pragma: no cover - trivial
+        flags = {
+            "predictions": self.FEATURE_PREDICTIONS,
+            "dashboard": self.FEATURE_DASHBOARD,
+            "advanced_tools": self.FEATURE_ADVANCED_TOOLS,
+            "web3_health": self.FEATURE_WEB3_HEALTH,
+            "portfolio": self.FEATURE_PORTFOLIO,
+            "insights": self.FEATURE_INSIGHTS,
+            "wallet": self.FEATURE_WALLET,
+        }
+        return tuple(name for name, enabled in flags.items() if enabled)
 
 
 @lru_cache()

--- a/app/core/features.py
+++ b/app/core/features.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, status
+
+from app.core.config import settings
+
+
+def require_feature(feature: str) -> None:
+    flag_name = f"FEATURE_{feature.upper()}"
+    enabled = getattr(settings, flag_name, False)
+    if not enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Feature '{feature}' is disabled",
+        )

--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from redis import Redis
+
+from app.core.config import settings
+
+
+@lru_cache(maxsize=1)
+def get_redis_client() -> Redis:
+    return Redis.from_url(settings.REDIS_URL, decode_responses=True)

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ def create_app() -> FastAPI:
 
     setup_cors(app)
     setup_api_key_middleware(app)
-    app.add_middleware(RateLimitMiddleware, limit=200, window=60)
+    app.add_middleware(RateLimitMiddleware)
 
     app.include_router(api_router, prefix=settings.API_V1_STR)
 

--- a/app/models/database/__init__.py
+++ b/app/models/database/__init__.py
@@ -1,8 +1,10 @@
 from app.models.database.alert import Alert
 from app.models.database.api_key import APIKey
+from app.models.database.insight import InsightEvent
 from app.models.database.index import MarketIndex, MarketIndexValue
 from app.models.database.market_data import MarketData
 from app.models.database.notification import Notification
+from app.models.database.portfolio import PortfolioAccount, PortfolioHolding, PortfolioSnapshot
 from app.models.database.prediction import Prediction
 from app.models.database.rate_limit import RateLimit
 from app.models.database.user import User

--- a/app/models/database/insight.py
+++ b/app/models/database/insight.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, Index, Numeric, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.database.common import BaseModel
+
+
+class InsightEvent(BaseModel):
+    __tablename__ = "insight_events"
+
+    ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True, nullable=False)
+    source: Mapped[str] = mapped_column(Enum("PROXY", "REDDIT", name="insight_event_source"), nullable=False)
+    asset_symbol: Mapped[str] = mapped_column(String(64), index=True, nullable=False)
+    text_excerpt: Mapped[str] = mapped_column(String(512), nullable=False)
+    sentiment_score: Mapped[float] = mapped_column(Numeric(precision=6, scale=3), nullable=False)
+    meta: Mapped[dict | None] = mapped_column(JSONB().with_variant(String, "sqlite"), nullable=True)
+
+
+Index("ix_insight_events_symbol_ts", InsightEvent.asset_symbol, InsightEvent.ts.desc())
+Index("ix_insight_events_source", InsightEvent.source)

--- a/app/models/database/portfolio.py
+++ b/app/models/database/portfolio.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, Numeric, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.database.common import BaseModel
+
+
+class PortfolioAccount(BaseModel):
+    __tablename__ = "portfolio_accounts"
+
+    user_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    type: Mapped[str] = mapped_column(Enum("CSV", name="portfolio_account_type"), nullable=False)
+
+    holdings: Mapped[list["PortfolioHolding"]] = relationship(
+        back_populates="account", cascade="all, delete-orphan", lazy="selectin"
+    )
+
+
+class PortfolioHolding(BaseModel):
+    __tablename__ = "portfolio_holdings"
+
+    account_id: Mapped[str] = mapped_column(ForeignKey("portfolio_accounts.id", ondelete="CASCADE"), nullable=False)
+    asset_symbol: Mapped[str] = mapped_column(String(64), nullable=False)
+    quantity: Mapped[float] = mapped_column(Numeric(precision=24, scale=10), nullable=False)
+    cost_basis: Mapped[float | None] = mapped_column(Numeric(precision=24, scale=10), nullable=True)
+
+    account: Mapped[PortfolioAccount] = relationship(back_populates="holdings")
+
+
+class PortfolioSnapshot(BaseModel):
+    __tablename__ = "portfolio_snapshots"
+
+    user_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    total_value: Mapped[float] = mapped_column(Numeric(precision=24, scale=10), nullable=False)
+    pnl_abs: Mapped[float] = mapped_column(Numeric(precision=24, scale=10), nullable=False)
+    pnl_pct: Mapped[float] = mapped_column(Numeric(precision=12, scale=6), nullable=False)
+
+
+Index(
+    "ix_portfolio_holdings_user_asset",
+    PortfolioHolding.account_id,
+    PortfolioHolding.asset_symbol,
+)

--- a/app/models/schemas/insights.py
+++ b/app/models/schemas/insights.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class InsightComponent(BaseModel):
+    name: str
+    value: float
+    trend: float | None = None
+
+
+class InsightSummary(BaseModel):
+    symbol: str
+    window: str
+    proxy_score: float = Field(ge=-1.0, le=1.0)
+    reddit_score: float | None = Field(default=None, ge=-1.0, le=1.0)
+    score_avg: float = Field(ge=-1.0, le=1.0)
+    score_trend: float | None = Field(default=None, ge=-1.0, le=1.0)
+    counts_by_source: dict[str, int]
+    components: List[InsightComponent]
+
+
+class InsightEventView(BaseModel):
+    id: str
+    ts: datetime
+    source: str
+    asset_symbol: str
+    text_excerpt: str
+    sentiment_score: float = Field(ge=-1.0, le=1.0)
+
+
+class InsightEventsResponse(BaseModel):
+    symbol: str
+    events: List[InsightEventView]

--- a/app/models/schemas/portfolio.py
+++ b/app/models/schemas/portfolio.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class PortfolioUploadResult(BaseModel):
+    account_id: str
+    imported_rows: int
+    skipped_rows: int
+
+
+class PortfolioHoldingView(BaseModel):
+    asset_symbol: str
+    quantity: Decimal
+    cost_basis: Decimal | None = None
+    market_price: Decimal | None = None
+    market_value: Decimal | None = None
+    pnl_abs: Decimal | None = None
+    pnl_pct: Decimal | None = None
+
+
+class PortfolioHoldingsResponse(BaseModel):
+    account_id: str
+    updated_at: datetime
+    holdings: List[PortfolioHoldingView]
+    totals: dict[str, Decimal]
+
+
+class PortfolioAllocationItem(BaseModel):
+    asset_symbol: str
+    weight_pct: float = Field(ge=0, le=100)
+    market_value: Decimal
+
+
+class PortfolioAllocationResponse(BaseModel):
+    account_id: str
+    allocation: List[PortfolioAllocationItem]
+    totals: dict[str, Decimal]
+
+
+class PortfolioPerformancePoint(BaseModel):
+    ts: datetime
+    total_value: Decimal
+    pnl_abs: Decimal
+    pnl_pct: Decimal
+
+
+class PortfolioPerformanceResponse(BaseModel):
+    user_id: str
+    window: str
+    points: List[PortfolioPerformancePoint]

--- a/app/services/external/__init__.py
+++ b/app/services/external/__init__.py
@@ -1,6 +1,7 @@
 """Client wrappers around upstream market data providers."""
 
+from .binance import BinanceClient
 from .coin_gecko import CoinGeckoClient
 from .dex_screener import DexScreenerClient
 
-__all__ = ["CoinGeckoClient", "DexScreenerClient"]
+__all__ = ["BinanceClient", "CoinGeckoClient", "DexScreenerClient"]

--- a/app/services/external/binance.py
+++ b/app/services/external/binance.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import httpx
+
+
+@dataclass
+class BinanceTicker:
+    symbol: str
+    price: float
+    bid: float
+    ask: float
+    volume: float
+    timestamp: datetime
+
+
+@dataclass
+class BinanceTrade:
+    price: float
+    qty: float
+    quote_qty: float
+    timestamp: datetime
+    is_buyer_maker: bool
+
+
+@dataclass
+class BinanceDepthLevel:
+    price: float
+    quantity: float
+
+
+class BinanceClient:
+    """Client for Binance public market data endpoints."""
+
+    def __init__(self, base_url: str = "https://api.binance.com/api/v3", timeout: float = 10.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def _request(self, path: str, params: Optional[Dict[str, str]] = None) -> Optional[dict]:
+        url = f"{self.base_url}{path}"
+        try:
+            response = httpx.get(url, params=params, timeout=self.timeout)
+            response.raise_for_status()
+        except httpx.HTTPError:
+            return None
+        return response.json()
+
+    def fetch_ticker(self, symbol: str) -> Optional[BinanceTicker]:
+        payload = self._request("/ticker/24hr", {"symbol": symbol.upper() + "USDT"})
+        if not payload:
+            return None
+        return BinanceTicker(
+            symbol=symbol.upper(),
+            price=float(payload.get("lastPrice", 0.0)),
+            bid=float(payload.get("bidPrice", 0.0)),
+            ask=float(payload.get("askPrice", 0.0)),
+            volume=float(payload.get("volume", 0.0)),
+            timestamp=datetime.utcnow(),
+        )
+
+    def fetch_depth(self, symbol: str, limit: int = 50) -> Optional[dict]:
+        payload = self._request("/depth", {"symbol": symbol.upper() + "USDT", "limit": str(limit)})
+        if not payload:
+            return None
+        return payload
+
+    def fetch_trades(self, symbol: str, limit: int = 200) -> List[BinanceTrade]:
+        payload = self._request("/trades", {"symbol": symbol.upper() + "USDT", "limit": str(limit)})
+        if not isinstance(payload, list):
+            return []
+        trades: List[BinanceTrade] = []
+        for entry in payload:
+            trades.append(
+                BinanceTrade(
+                    price=float(entry.get("price", 0.0)),
+                    qty=float(entry.get("qty", 0.0)),
+                    quote_qty=float(entry.get("quoteQty", 0.0)),
+                    timestamp=datetime.fromtimestamp(entry.get("time", 0) / 1000.0),
+                    is_buyer_maker=bool(entry.get("isBuyerMaker", False)),
+                )
+            )
+        return trades

--- a/app/services/health.py
+++ b/app/services/health.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import httpx
+from redis import Redis
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.redis import get_redis_client
+
+
+@dataclass
+class HealthStatus:
+    name: str
+    status: str
+    details: Dict[str, str] | None = None
+
+
+def _check_database(session: Session) -> HealthStatus:
+    try:
+        session.execute("SELECT 1")
+        return HealthStatus(name="database", status="healthy")
+    except Exception as exc:  # pragma: no cover - defensive
+        return HealthStatus(name="database", status="degraded", details={"error": str(exc)})
+
+
+def _check_redis() -> HealthStatus:
+    try:
+        client: Redis = get_redis_client()
+        client.ping()
+        return HealthStatus(name="redis", status="healthy")
+    except Exception as exc:  # pragma: no cover
+        return HealthStatus(name="redis", status="degraded", details={"error": str(exc)})
+
+
+def _check_http_endpoint(name: str, url: str) -> HealthStatus:
+    try:
+        response = httpx.get(url, timeout=5.0)
+        if response.status_code < 500:
+            return HealthStatus(name=name, status="healthy")
+        return HealthStatus(name=name, status="degraded", details={"status": str(response.status_code)})
+    except Exception as exc:  # pragma: no cover
+        return HealthStatus(name=name, status="degraded", details={"error": str(exc)})
+
+
+def run_health_checks(session: Session) -> Dict[str, HealthStatus]:
+    checks = {
+        "database": _check_database(session),
+        "redis": _check_redis(),
+        "coingecko": _check_http_endpoint("coingecko", f"{settings.COINGECKO_BASE_URL}/ping"),
+        "binance": _check_http_endpoint("binance", f"{settings.BINANCE_BASE_URL}/ping"),
+    }
+    if settings.DEXSCREENER_ENABLED:
+        checks["dexscreener"] = _check_http_endpoint("dexscreener", f"{settings.DEXSCREENER_BASE_URL}/search?q=eth")
+    return checks

--- a/app/services/insights.py
+++ b/app/services/insights.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+from app.core.config import settings
+from app.models.database.insight import InsightEvent
+from app.models.schemas.insights import (
+    InsightComponent,
+    InsightEventView,
+    InsightEventsResponse,
+    InsightSummary,
+)
+from app.services.external import DexScreenerClient
+
+
+analyzer = SentimentIntensityAnalyzer()
+dex_client = DexScreenerClient(base_url=settings.DEXSCREENER_BASE_URL)
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+def compute_proxy_components(symbol: str) -> Dict[str, float]:
+    pair = dex_client.search_pair(symbol)
+    if not pair:
+        return {
+            "buy_sell_ratio": 0.0,
+            "vol_change_24h": 0.0,
+            "tx_velocity": 0.0,
+        }
+    txns = pair.transactions or {}
+    h24 = txns.get("h24", {})
+    h1 = txns.get("h1", {})
+    buys_24 = float(h24.get("buys", 0))
+    sells_24 = float(h24.get("sells", 0))
+    total_24 = buys_24 + sells_24
+    ratio = _safe_ratio(buys_24 - sells_24, total_24)
+    total_1h = float(h1.get("buys", 0) + h1.get("sells", 0))
+    tx_velocity = total_1h
+    vol_change = 0.0
+    if pair.volume_24h:
+        # crude approximation: compare 1h extrapolated volume with 24h
+        vol_change = _safe_ratio(total_1h * 24 - total_24, total_24)
+    return {
+        "buy_sell_ratio": max(min(ratio, 1.0), -1.0),
+        "vol_change_24h": max(min(vol_change, 1.0), -1.0),
+        "tx_velocity": total_1h,
+    }
+
+
+def compute_proxy_score(components: Dict[str, float]) -> float:
+    score = 0.6 * components.get("buy_sell_ratio", 0.0) + 0.4 * components.get("vol_change_24h", 0.0)
+    return max(min(score, 1.0), -1.0)
+
+
+def generate_proxy_events(symbol: str, components: Dict[str, float]) -> List[InsightEvent]:
+    events: List[InsightEvent] = []
+    ratio = components.get("buy_sell_ratio", 0.0)
+    vol_change = components.get("vol_change_24h", 0.0)
+    timestamp = datetime.utcnow()
+    if abs(ratio) >= 0.2:
+        direction = "Buy" if ratio > 0 else "Sell"
+        text = f"{direction} pressure {ratio * 100:.1f}% vs sells in last 24h"
+        events.append(
+            InsightEvent(
+                ts=timestamp,
+                source="PROXY",
+                asset_symbol=symbol.upper(),
+                text_excerpt=text,
+                sentiment_score=ratio,
+                meta={"component": "buy_sell_ratio"},
+            )
+        )
+    if abs(vol_change) >= 0.15:
+        text = f"Volume momentum {vol_change * 100:.1f}% vs 24h baseline"
+        events.append(
+            InsightEvent(
+                ts=timestamp,
+                source="PROXY",
+                asset_symbol=symbol.upper(),
+                text_excerpt=text,
+                sentiment_score=vol_change,
+                meta={"component": "vol_change_24h"},
+            )
+        )
+    return events
+
+
+def refresh_proxy_insights(session: Session, symbol: str) -> List[InsightEvent]:
+    components = compute_proxy_components(symbol)
+    events = generate_proxy_events(symbol, components)
+    for event in events:
+        session.add(event)
+    session.commit()
+    return events
+
+
+def summarise_insights(session: Session, symbol: str, window: str) -> InsightSummary:
+    components = compute_proxy_components(symbol)
+    proxy_score = compute_proxy_score(components)
+    window_minutes = 24 * 60
+    if window.endswith("h"):
+        window_minutes = int(window[:-1]) * 60
+    elif window.endswith("d"):
+        window_minutes = int(window[:-1]) * 24 * 60
+    cutoff = datetime.utcnow() - timedelta(minutes=window_minutes)
+
+    events = (
+        session.query(InsightEvent)
+        .filter(
+            InsightEvent.asset_symbol == symbol.upper(),
+            InsightEvent.ts >= cutoff,
+        )
+        .order_by(desc(InsightEvent.ts))
+        .all()
+    )
+    reddit_scores = [float(event.sentiment_score) for event in events if event.source == "REDDIT"]
+    reddit_score = sum(reddit_scores) / len(reddit_scores) if reddit_scores else None
+    combined_scores = [proxy_score] + reddit_scores
+    avg_score = sum(combined_scores) / len(combined_scores) if combined_scores else 0.0
+    counts = {"PROXY": 0, "REDDIT": 0}
+    for event in events:
+        counts[event.source] = counts.get(event.source, 0) + 1
+    insight_components = [
+        InsightComponent(name=name, value=value)
+        for name, value in components.items()
+    ]
+    return InsightSummary(
+        symbol=symbol.upper(),
+        window=window,
+        proxy_score=proxy_score,
+        reddit_score=reddit_score,
+        score_avg=max(min(avg_score, 1.0), -1.0),
+        score_trend=None,
+        counts_by_source=counts,
+        components=insight_components,
+    )
+
+
+def list_events(session: Session, symbol: str, limit: int = 50) -> InsightEventsResponse:
+    records = (
+        session.query(InsightEvent)
+        .filter(InsightEvent.asset_symbol == symbol.upper())
+        .order_by(desc(InsightEvent.ts))
+        .limit(limit)
+        .all()
+    )
+    events = [
+        InsightEventView(
+            id=record.id,
+            ts=record.ts,
+            source=record.source,
+            asset_symbol=record.asset_symbol,
+            text_excerpt=record.text_excerpt,
+            sentiment_score=float(record.sentiment_score),
+        )
+        for record in records
+    ]
+    return InsightEventsResponse(symbol=symbol.upper(), events=events)
+
+
+def ingest_reddit_post(session: Session, symbol: str, text: str) -> InsightEvent:
+    sentiment = analyzer.polarity_scores(text)["compound"]
+    event = InsightEvent(
+        ts=datetime.utcnow(),
+        source="REDDIT",
+        asset_symbol=symbol.upper(),
+        text_excerpt=text[:480],
+        sentiment_score=sentiment,
+        meta={"length": len(text)},
+    )
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+    return event

--- a/app/services/portfolio.py
+++ b/app/services/portfolio.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from datetime import datetime, timedelta
+from decimal import Decimal
+from io import StringIO
+from typing import Dict, Iterable, List, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.models.database.portfolio import PortfolioAccount, PortfolioHolding, PortfolioSnapshot
+from app.models.schemas.portfolio import (
+    PortfolioAllocationItem,
+    PortfolioAllocationResponse,
+    PortfolioHoldingView,
+    PortfolioHoldingsResponse,
+    PortfolioPerformancePoint,
+    PortfolioPerformanceResponse,
+    PortfolioUploadResult,
+)
+from app.services.market_data import get_latest_price
+
+
+REQUIRED_FIELDS = {"asset_symbol", "quantity"}
+OPTIONAL_FIELDS = {"cost_basis"}
+FIELD_ALIASES = {
+    "asset": "asset_symbol",
+    "symbol": "asset_symbol",
+    "ticker": "asset_symbol",
+    "qty": "quantity",
+    "amount": "quantity",
+    "cost": "cost_basis",
+    "price_paid": "cost_basis",
+}
+
+
+def _normalise_headers(headers: Iterable[str]) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for header in headers:
+        canonical = FIELD_ALIASES.get(header.strip().lower(), header.strip().lower())
+        mapping[header] = canonical
+    return mapping
+
+
+def _parse_decimal(value: str | float | int | None) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return Decimal(value)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _aggregate_rows(rows: Iterable[dict]) -> Tuple[List[dict], int]:
+    aggregated: Dict[str, Dict[str, Decimal]] = defaultdict(lambda: {"quantity": Decimal(0), "cost_basis": Decimal(0)})
+    skipped = 0
+    for row in rows:
+        symbol_raw = row.get("asset_symbol")
+        quantity_raw = row.get("quantity")
+        if not symbol_raw or quantity_raw in (None, ""):
+            skipped += 1
+            continue
+        symbol = str(symbol_raw).upper().strip()
+        quantity = _parse_decimal(quantity_raw)
+        if quantity is None:
+            skipped += 1
+            continue
+        cost_basis_value = _parse_decimal(row.get("cost_basis"))
+        data = aggregated[symbol]
+        data["quantity"] += quantity
+        if cost_basis_value is not None:
+            data["cost_basis"] += cost_basis_value
+    normalized_rows = []
+    for symbol, data in aggregated.items():
+        normalized_rows.append(
+            {
+                "asset_symbol": symbol,
+                "quantity": data["quantity"],
+                "cost_basis": data["cost_basis"] if data["cost_basis"] != 0 else None,
+            }
+        )
+    return normalized_rows, skipped
+
+
+def parse_portfolio_csv(content: bytes) -> Tuple[List[dict], int]:
+    text = content.decode("utf-8")
+    reader = csv.DictReader(StringIO(text))
+    header_map = _normalise_headers(reader.fieldnames or [])
+    normalised_rows: List[dict] = []
+    for row in reader:
+        normalised: Dict[str, str] = {}
+        for key, value in row.items():
+            canonical = header_map.get(key)
+            if canonical:
+                normalised[canonical] = value
+        normalised_rows.append(normalised)
+    return _aggregate_rows(normalised_rows)
+
+
+def _get_or_create_csv_account(session: Session, user_id: str) -> PortfolioAccount:
+    account = (
+        session.query(PortfolioAccount)
+        .filter(PortfolioAccount.user_id == user_id, PortfolioAccount.type == "CSV")
+        .first()
+    )
+    if account:
+        return account
+    account = PortfolioAccount(user_id=user_id, name="CSV Portfolio", type="CSV")
+    session.add(account)
+    session.commit()
+    session.refresh(account)
+    return account
+
+
+def upsert_holdings_from_csv(session: Session, user_id: str, content: bytes) -> PortfolioUploadResult:
+    rows, skipped = parse_portfolio_csv(content)
+    if not rows:
+        raise ValueError("No valid rows found in CSV upload")
+
+    account = _get_or_create_csv_account(session, user_id)
+    session.query(PortfolioHolding).filter(PortfolioHolding.account_id == account.id).delete()
+    imported = 0
+    for row in rows:
+        holding = PortfolioHolding(
+            account_id=account.id,
+            asset_symbol=row["asset_symbol"],
+            quantity=row["quantity"],
+            cost_basis=row.get("cost_basis"),
+        )
+        session.add(holding)
+        imported += 1
+    session.commit()
+    record_snapshot(session, user_id)
+    return PortfolioUploadResult(account_id=account.id, imported_rows=imported, skipped_rows=skipped)
+
+
+def _convert_decimal(value: Decimal | float | None) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _compute_holdings_totals(holdings: List[PortfolioHoldingView]) -> Dict[str, Decimal]:
+    total_value = sum((holding.market_value or Decimal("0")) for holding in holdings)
+    total_cost = sum((_convert_decimal(holding.cost_basis) or Decimal("0")) for holding in holdings if holding.cost_basis)
+    total_quantity = sum(holding.quantity for holding in holdings)
+    return {
+        "total_value": total_value.quantize(Decimal("0.01")) if total_value else Decimal("0"),
+        "total_cost": total_cost.quantize(Decimal("0.01")) if total_cost else Decimal("0"),
+        "total_quantity": total_quantity,
+    }
+
+
+def fetch_holdings(session: Session, user_id: str) -> PortfolioHoldingsResponse:
+    account = (
+        session.query(PortfolioAccount)
+        .filter(PortfolioAccount.user_id == user_id, PortfolioAccount.type == "CSV")
+        .first()
+    )
+    if not account:
+        return PortfolioHoldingsResponse(
+            account_id="",
+            updated_at=datetime.utcnow(),
+            holdings=[],
+            totals={"total_value": Decimal("0"), "total_cost": Decimal("0"), "total_quantity": Decimal("0")},
+        )
+
+    holdings_models = (
+        session.query(PortfolioHolding)
+        .filter(PortfolioHolding.account_id == account.id)
+        .order_by(PortfolioHolding.asset_symbol.asc())
+        .all()
+    )
+    holdings: List[PortfolioHoldingView] = []
+    for model in holdings_models:
+        market_price = get_latest_price(session, model.asset_symbol)
+        price_decimal = Decimal(str(market_price.price)) if market_price else None
+        market_value = price_decimal * Decimal(model.quantity) if price_decimal is not None else None
+        cost_basis = Decimal(model.cost_basis) if model.cost_basis is not None else None
+        pnl_abs = None
+        pnl_pct = None
+        if market_value is not None and cost_basis is not None and cost_basis != 0:
+            pnl_abs = market_value - cost_basis
+            pnl_pct = float((pnl_abs / cost_basis) * 100)
+        holdings.append(
+            PortfolioHoldingView(
+                asset_symbol=model.asset_symbol,
+                quantity=Decimal(model.quantity),
+                cost_basis=cost_basis,
+                market_price=price_decimal,
+                market_value=market_value,
+                pnl_abs=pnl_abs,
+                pnl_pct=pnl_pct,
+            )
+        )
+    totals = _compute_holdings_totals(holdings)
+    return PortfolioHoldingsResponse(
+        account_id=account.id,
+        updated_at=account.updated_at,
+        holdings=holdings,
+        totals=totals,
+    )
+
+
+def compute_allocation(session: Session, user_id: str) -> PortfolioAllocationResponse:
+    holdings_response = fetch_holdings(session, user_id)
+    total_value = holdings_response.totals.get("total_value", Decimal("0"))
+    allocation: List[PortfolioAllocationItem] = []
+    for holding in holdings_response.holdings:
+        market_value = holding.market_value or Decimal("0")
+        if total_value > 0:
+            weight = float((market_value / total_value) * 100)
+        else:
+            weight = 0.0
+        allocation.append(
+            PortfolioAllocationItem(
+                asset_symbol=holding.asset_symbol,
+                market_value=market_value,
+                weight_pct=round(weight, 2),
+            )
+        )
+    return PortfolioAllocationResponse(
+        account_id=holdings_response.account_id,
+        allocation=allocation,
+        totals=holdings_response.totals,
+    )
+
+
+def record_snapshot(session: Session, user_id: str) -> PortfolioSnapshot:
+    holdings = fetch_holdings(session, user_id)
+    total_value = _convert_decimal(holdings.totals.get("total_value"))
+    total_cost = _convert_decimal(holdings.totals.get("total_cost"))
+    pnl_abs = total_value - total_cost
+    pnl_pct = float((pnl_abs / total_cost) * 100) if total_cost else 0.0
+    snapshot = PortfolioSnapshot(
+        user_id=user_id,
+        total_value=total_value,
+        pnl_abs=pnl_abs,
+        pnl_pct=pnl_pct,
+    )
+    session.add(snapshot)
+    session.commit()
+    session.refresh(snapshot)
+    return snapshot
+
+
+WINDOW_TO_DAYS = {"7d": 7, "30d": 30, "90d": 90}
+
+
+def get_performance(session: Session, user_id: str, window: str) -> PortfolioPerformanceResponse:
+    days = WINDOW_TO_DAYS.get(window)
+    if days is None:
+        raise ValueError("Unsupported window")
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    snapshots = (
+        session.query(PortfolioSnapshot)
+        .filter(PortfolioSnapshot.user_id == user_id, PortfolioSnapshot.ts >= cutoff)
+        .order_by(PortfolioSnapshot.ts.asc())
+        .all()
+    )
+    points = [
+        PortfolioPerformancePoint(
+            ts=record.ts,
+            total_value=Decimal(record.total_value),
+            pnl_abs=Decimal(record.pnl_abs),
+            pnl_pct=Decimal(record.pnl_pct),
+        )
+        for record in snapshots
+    ]
+    return PortfolioPerformanceResponse(user_id=user_id, window=window, points=points)

--- a/app/services/prediction.py
+++ b/app/services/prediction.py
@@ -28,6 +28,7 @@ HORIZON_TO_HOURS: Dict[str, int] = {
     "1h": 1,
     "4h": 4,
     "24h": 24,
+    "1d": 24,
     "7d": 24 * 7,
 }
 
@@ -372,6 +373,7 @@ def get_prediction_history(
     start_date: datetime | None = None,
     end_date: datetime | None = None,
     include_accuracy: bool = True,
+    limit: int | None = None,
 ) -> PredictionHistoryResponse:
     symbol = symbol.upper()
     query = db.query(Prediction).filter(Prediction.symbol == symbol)
@@ -379,7 +381,10 @@ def get_prediction_history(
         query = query.filter(Prediction.prediction_time >= start_date)
     if end_date:
         query = query.filter(Prediction.prediction_time <= end_date)
-    records = query.order_by(desc(Prediction.prediction_time)).all()
+    query = query.order_by(desc(Prediction.prediction_time))
+    if limit:
+        query = query.limit(limit)
+    records = query.all()
     items = [
         PredictionHistoryItem(
             prediction_time=record.prediction_time,

--- a/app/services/web3.py
+++ b/app/services/web3.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from app.core.config import settings
+from app.services.external import DexScreenerClient
+
+
+@dataclass
+class Web3Pool:
+    address: str
+    chain: str
+    liquidity_usd: float | None
+    price_usd: float | None
+
+
+@dataclass
+class Web3Health:
+    symbol: str
+    liquidity: float | None
+    vol24h: float | None
+    tx_per_hour: float
+    pools: List[Web3Pool]
+    last_updated: datetime
+
+
+dex_client = DexScreenerClient(base_url=settings.DEXSCREENER_BASE_URL)
+_cache: Dict[str, Web3Health] = {}
+_cache_expiry: Dict[str, datetime] = {}
+
+
+def _from_pair(symbol: str, pair) -> Web3Health:
+    txns = pair.transactions or {}
+    h1 = txns.get("h1", {})
+    total_tx = float(h1.get("buys", 0) + h1.get("sells", 0))
+    tx_per_hour = total_tx
+    pool = Web3Pool(
+        address=pair.pair_address,
+        chain=pair.chain_id,
+        liquidity_usd=pair.liquidity_usd,
+        price_usd=pair.price_usd,
+    )
+    return Web3Health(
+        symbol=symbol.upper(),
+        liquidity=pair.liquidity_usd,
+        vol24h=pair.volume_24h,
+        tx_per_hour=tx_per_hour,
+        pools=[pool],
+        last_updated=datetime.utcnow(),
+    )
+
+
+def get_web3_health(symbol: str) -> Web3Health:
+    symbol = symbol.upper()
+    now = datetime.utcnow()
+    cached = _cache.get(symbol)
+    expiry = _cache_expiry.get(symbol)
+    if cached and expiry and expiry > now:
+        return cached
+
+    pair = dex_client.search_pair(symbol)
+    if pair:
+        health = _from_pair(symbol, pair)
+        _cache[symbol] = health
+        _cache_expiry[symbol] = now + timedelta(seconds=settings.CACHE_TTL_SECONDS)
+        return health
+
+    if cached:
+        return cached
+
+    return Web3Health(
+        symbol=symbol,
+        liquidity=None,
+        vol24h=None,
+        tx_per_hour=0.0,
+        pools=[],
+        last_updated=now,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@ prophet==1.1.5
 python-dotenv==1.0.1
 prometheus-client==0.20.0
 requests==2.31.0
+python-dateutil==2.9.0.post0
+vaderSentiment==3.3.2
+python-multipart==0.0.20
 pytest==8.1.1
 pytest-asyncio==0.23.5
 pytest-cov==5.0.0

--- a/tests/integration/test_dashboard_metadata.py
+++ b/tests/integration/test_dashboard_metadata.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+
+
+def test_dashboard_metadata(client: TestClient, monkeypatch):
+    monkeypatch.setattr(settings, "FEATURE_DASHBOARD", True)
+    response = client.get("/api/v1/dashboard/metadata")
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert any(widget["name"] == "priceTicker" for widget in data["widgets"])
+    assert "/ws/market" in data["websockets"]

--- a/tests/integration/test_insights_endpoints.py
+++ b/tests/integration/test_insights_endpoints.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+
+
+def test_insights_endpoints(client: TestClient, monkeypatch):
+    monkeypatch.setattr(settings, "FEATURE_INSIGHTS", True)
+
+    monkeypatch.setattr(
+        "app.services.insights.compute_proxy_components",
+        lambda symbol: {"buy_sell_ratio": 0.4, "vol_change_24h": 0.1, "tx_velocity": 12},
+    )
+
+    summary = client.get("/api/v1/insights/summary", params={"symbol": "BTC"})
+    assert summary.status_code == 200
+    data = summary.json()["data"]
+    assert data["proxy_score"] > 0
+    assert data["counts_by_source"]["PROXY"] >= 0
+
+    events = client.get("/api/v1/insights/events", params={"symbol": "BTC"})
+    assert events.status_code == 200
+    assert events.json()["data"]["events"] == []

--- a/tests/integration/test_portfolio_endpoints.py
+++ b/tests/integration/test_portfolio_endpoints.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+
+
+CSV_CONTENT = "asset_symbol,quantity,cost_basis\nBTC,0.5,10000\nETH,2,3000\n"
+
+
+def test_portfolio_upload_and_views(client: TestClient, monkeypatch):
+    monkeypatch.setattr(settings, "FEATURE_PORTFOLIO", True)
+
+    files = {"file": ("holdings.csv", BytesIO(CSV_CONTENT.encode()), "text/csv")}
+    upload = client.post("/api/v1/portfolio/upload", files=files)
+    assert upload.status_code == 200
+    payload = upload.json()["data"]
+    assert payload["imported_rows"] == 2
+
+    holdings = client.get("/api/v1/portfolio/holdings")
+    assert holdings.status_code == 200
+    holdings_data = holdings.json()["data"]
+    assert len(holdings_data["holdings"]) == 2
+
+    allocation = client.get("/api/v1/portfolio/allocation")
+    assert allocation.status_code == 200
+    allocation_data = allocation.json()["data"]
+    assert len(allocation_data["allocation"]) == 2
+
+    performance = client.get("/api/v1/portfolio/performance", params={"window": "30d"})
+    assert performance.status_code == 200
+    performance_data = performance.json()["data"]
+    assert performance_data["window"] == "30d"
+    assert len(performance_data["points"]) >= 1

--- a/tests/integration/test_web3_endpoints.py
+++ b/tests/integration/test_web3_endpoints.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+
+
+def test_web3_health_endpoint(client: TestClient, monkeypatch):
+    monkeypatch.setattr(settings, "FEATURE_WEB3_HEALTH", True)
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.web3.get_web3_health",
+        lambda symbol: type(
+            "MockHealth",
+            (),
+            {
+                "symbol": symbol.upper(),
+                "liquidity": 100000.0,
+                "vol24h": 500000.0,
+                "tx_per_hour": 12.0,
+                "pools": [],
+                "last_updated": __import__("datetime").datetime.utcnow(),
+            },
+        )(),
+    )
+
+    response = client.get("/api/v1/web3/health", params={"symbol": "ETH"})
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["symbol"] == "ETH"
+    assert body["liquidity"] == 100000.0


### PR DESCRIPTION
## Summary
- add feature-flagged portfolio CSV ingestion with valuation/allocation/performance APIs and tests
- deliver Community Insights v0 via DexScreener sentiment proxy plus optional Reddit hook, with new endpoints and models
- harden health/metrics, Web3 health, WebSocket feeds, and dashboard metadata; document setup in README_FREE_MVP

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d57f439dd0833099d0546d73087c4e